### PR TITLE
Add a more complicated build hierarchy more closely resembling the real world

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -7,3 +7,6 @@
 ; when you change it all users will automatically get updated.
 ; [please]
 ; version = 16.22.1
+
+[buildconfig]
+terraform-target = "terraform"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,65 @@ Plan: 2 to add, 0 to change, 0 to destroy.
 
 Module source paths: The module source paths are relative to the monorepo root (`.plzconfig` file) if targeting a module defined by the `terraform_module` rule. Module source paths are relative to the current working directory if targeting a module that is in the application folder.
 
+rule name: there is baked in assumptions that the rule names used across the board for all `terraform_roots` and `terraform_modules` is the same. By default it expects `terraform`, but it can be configured by setting the build config `terraform-target`.
+
 ## Pre-reqs
 
-- If the please wrapper (pleasew) does not work, install please from the website.
-https://please.build/index.html
+- If the please wrapper (pleasew) does not work, install please from the [website.](https://please.build/index.html)
+
+
+## examples
+
+### Module referencing another module
+```
+subinclude("//terraform:terraform")
+
+terraform_module(
+    name = "terraform",
+    srcs = glob("**.tf"),
+    deps = ["//platform-team/modules/module2:terraform"], # reference the terraform_module target
+    visibility = ["PUBLIC"]
+)
+```
+
+### Using a local module without defining it as a terraform_module
+
+```
+terraform_root(
+    name = "terraform",
+    srcs = glob("**.tf", "modules/module1/**.tf"), # include it with glob, be sure to exclude the things included with modules
+    #srcs = glob("*.tf") + glob("modules/module2/*.tf"), could also choose to be more picky with the globbing instead of excluding
+    modules = ["//platform-team/modules/module1:terraform", "//services/service1/modules/module1:terraform"]
+)
+```
+
+### Defining a module with no folder hierachy
+
+```
+subinclude("//terraform:terraform")
+
+terraform_module(
+    name = "terraform",
+    srcs = glob("**.tf"),
+    visibility = ["PUBLIC"]
+)
+```
+
+### Defining a terraform root
+
+```
+subinclude("//terraform:terraform")
+
+terraform_root(
+    name = "terraform",
+    srcs = glob("**.tf", "modules/module1/**.tf"),
+    modules = ["//platform-team/modules/module1:terraform", "//services/service1/modules/module1:terraform"]
+)
+```
+
+## Things still missing
+Building a docker container with the terraform (think CNAB), so one can run `terraform apply` via a docker container with all the terraform set up.
+
+Try to remove baked in dependency on a defined out folder label (`terraform-target`)
+
+Allow user provided inputs (--var-file, --var) into the terraform workflow targets

--- a/platform-team/modules/module1/main.tf
+++ b/platform-team/modules/module1/main.tf
@@ -3,3 +3,7 @@ resource "null_resource" "resource2" {
     key = var.a_string_variable
   }
 }
+
+module "module_using_module2" {
+  source = "./platform-team/modules/module2"
+}

--- a/platform-team/modules/module2/BUILD
+++ b/platform-team/modules/module2/BUILD
@@ -3,6 +3,5 @@ subinclude("//terraform:terraform")
 terraform_module(
     name = "terraform",
     srcs = glob("**.tf"),
-    deps = ["//platform-team/modules/module2:terraform"],
     visibility = ["PUBLIC"]
 )

--- a/platform-team/modules/module2/module2.tf
+++ b/platform-team/modules/module2/module2.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "resource1" {}

--- a/services/service1/BUILD
+++ b/services/service1/BUILD
@@ -2,6 +2,6 @@ subinclude("//terraform:terraform")
 
 terraform_root(
     name = "terraform",
-    srcs = glob("**.tf"),
-    modules = ["//platform-team/modules/module1:terraform"]
+    srcs = glob("**.tf", "modules/module1/**.tf"),
+    modules = ["//platform-team/modules/module1:terraform", "//services/service1/modules/module1:terraform"]
 )

--- a/services/service1/main.tf
+++ b/services/service1/main.tf
@@ -3,3 +3,12 @@ module "module1" {
   source            = "./platform-team/modules/module1"
   a_string_variable = "stuff"
 }
+
+module "module2" {
+  source = "./services/service1/modules/module1"
+}
+
+
+module "local_module1" {
+  source = "./modules/module2"
+}

--- a/services/service1/modules/module1/BUILD
+++ b/services/service1/modules/module1/BUILD
@@ -3,6 +3,5 @@ subinclude("//terraform:terraform")
 terraform_module(
     name = "terraform",
     srcs = glob("**.tf"),
-    deps = ["//platform-team/modules/module2:terraform"],
     visibility = ["PUBLIC"]
 )

--- a/services/service1/modules/module1/module1_main.tf
+++ b/services/service1/modules/module1/module1_main.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "resource1" {}

--- a/services/service1/modules/module2/module2_main.tf
+++ b/services/service1/modules/module2/module2_main.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "resource1" {}

--- a/terraform/prepare_module/main.py
+++ b/terraform/prepare_module/main.py
@@ -1,10 +1,15 @@
 import sys
 import argparse
 import shutil
+import logging
+import os
 
-print("preparing module with args: " + " ".join(sys.argv))
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
 
-parser = argparse.ArgumentParser(description='Process some integers.')
+log.info("preparing module with args: " + " ".join(sys.argv))
+
+parser = argparse.ArgumentParser(description='Prepare a terraform module')
 parser.add_argument('--pkg', type=str)
 parser.add_argument('--name', type=str)
 parser.add_argument('--module-dir', type=str)
@@ -12,6 +17,20 @@ parser.add_argument('--out', type=str)
 parser.add_argument('--out-dirs', type=str)
 parser.add_argument('--strip', type=str)
 parser.add_argument('--deps', type=str)
+parser.add_argument('--modules', type=str, nargs='+')
+
 args = parser.parse_args()
+print(args)
 
 shutil.move(args.module_dir, args.out)
+
+modules = args.modules
+
+for module in args.modules:
+    if module is '':
+        # if modules is left blank, the way it is passed results in a list with an empty string
+        # maybe just pretend like that doesn't happen and continue on with our day
+        continue
+    module_path = module.rstrip("/" + os.environ.get("TERRAFORM_TARGET"))
+    log.info(f"Moving {module} to {args.out}/{module_path}")
+    shutil.copytree(module, args.out + "/" + module_path)

--- a/terraform/prepare_workspace/main.py
+++ b/terraform/prepare_workspace/main.py
@@ -2,8 +2,13 @@ import argparse
 import shutil
 from pathlib import Path
 import sys
+import logging
+import os
 
-print("preparing root with args: " + " ".join(sys.argv))
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+
+log.info("preparing root with args: " + " ".join(sys.argv))
 
 parser = argparse.ArgumentParser(description='Prepare a please terraform workspace')
 parser.add_argument('--pkg',type=str)
@@ -19,7 +24,7 @@ args = parser.parse_args()
 
 pkg = args.pkg
 name = args.name
-os = args.os
+os_arg = args.os
 arch = args.arch
 out = args.out
 pkg_dir = args.pkg_dir
@@ -32,11 +37,26 @@ sources_as_list = srcs[1:-1].split(" ")
 Path(out).mkdir(parents=True, exist_ok=True)
 
 for src in sources_as_list:
-    shutil.copy(f"{pkg_dir}/{src}", out)
+    file_path = Path(src)
+    file_path = os.path.dirname(file_path)
+    destination = out
+    if file_path:
+        # support a module containing module references relative
+        # to the current path that have not been set up as a
+        # please terraform_module
+        log.debug(f"File has path {file_path}")
+        destination =  out + "/" + file_path
+        Path(destination).mkdir(parents=True, exist_ok=True)
 
+    log.debug(f"Copying {src} to {destination}")
+    shutil.copy(f"{pkg_dir}/{src}", destination)
+
+log.debug(modules)
 for module in modules:
     # this is a side effect of having the `/terraform` out directory
     # ideally there would be a better way to figure this out, but
-    # I don't know what that would look like
-    new_path = module.rstrip("/terraform")
+    # I don't know what that would look like...
+    # if the terraform_module is NOT set up using the terraform
+    # label we won't find it :(
+    new_path = module.rstrip("/" + os.environ.get("TERRAFORM_TARGET"))
     shutil.copytree(module, f"{out}/{new_path}")

--- a/terraform/terraform.build_defs
+++ b/terraform/terraform.build_defs
@@ -1,3 +1,5 @@
+TERRAFORM_TARGET = CONFIG.get('TERRAFORM_TARGET') or "terraform"
+
 def terraform_module(
     name: str,
     srcs: list = None,
@@ -30,6 +32,11 @@ def terraform_module(
 
     deps=[canonicalise(dep) for dep in deps]
 
+    # building a string to place into CMD that'll get subbed with directories
+    modules_fancy = [f"$(locations {module})" for module in deps]
+    modules_subbed = " ".join(modules_fancy)
+
+
     genrule(
         name = name,
         srcs = [module_srcs_dir],
@@ -43,6 +50,7 @@ $TOOLS \\
     --pkg="$PKG" \\
     --name="$NAME" \\
     --module-dir="$SRCS" \\
+    --modules={modules_subbed} \\
     --out="$OUTS" \\
     --out-dir=$OUT_DIRS \\
     --strip="{strip}" \\
@@ -50,6 +58,7 @@ $TOOLS \\
         """,
         env = {
             "OUT_DIRS": name,
+            "TERRAFORM_TARGET": TERRAFORM_TARGET
         }
     )
 
@@ -99,8 +108,11 @@ def terraform_root(
                 --pkg-dir="$PKG_DIR" \\
                 --srcs="{srcs}" \\
                 --var-files="{var_files}" \\
-                --modules="{modules_subbed}"
+                --modules {modules_subbed}
         """,
+        env = {
+            "TERRAFORM_TARGET": TERRAFORM_TARGET
+        }
     )
 
     if add_default_workflows:


### PR DESCRIPTION
The real world has a few more things that we do in terraform, this expands the repo and the rules to include some of the ones that we do regarding referencing of modules.